### PR TITLE
Fix DOUBLE SETTLE BUG IN HOOK FUNCTION

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,8 +30,7 @@ exports.handleMessage = function(hook_name, context, callback){
     }
   }
   if(!isDeleteRequest){
-    callback(false);
-    return false;
+    return callback(false);
   }
   
   console.log('DELETION REQUEST!')

--- a/static/js/delete_button.js
+++ b/static/js/delete_button.js
@@ -11,6 +11,9 @@ function sendDeletionRequest(){
   }
   pad.collabClient.sendMessage(message);
   modals.showModal('deleted');
+  
+  // reload window, so that the current content is discarded:
+  window.location.reload();
 }
 
 exports.documentReady = function(hook_name, args, cb) {


### PR DESCRIPTION
## Further Notes

- When we include the current version of the plugin ep_push2delete, we receive the current error message; the etherpad app or the pad does not break, but this error message needs to be resolved

```txt
[2023-02-20 19:53:12.599] [ERROR] console - DOUBLE SETTLE BUG IN HOOK FUNCTION (plugin: ep_push2delete, function name: /opt/etherpad-lite/node_modules/ep_push2delete/index:handleMessage, hook: handleMessage): Attempt to resolve via returned value but it already resolved via callback. Ignoring this attempt to resolve.
```

This pull request takes care of this.

## New Features / Enhancements

- [x] Fix DOUBLE SETTLE BUG IN HOOK FUNCTION, see 3f5a988083c628c01248f1e85b04c59f23b81582

## After Merge Checklist